### PR TITLE
Test cases for https://github.com/unirgy/convertm1m2/issues/40

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
     "require-dev": {
         "phpunit/phpunit": "4.8.*"
+    },
+    "scripts":{
+        "test":"vendor/bin/phpunit tests"
     }
 }

--- a/tests/AllcapsTest.php
+++ b/tests/AllcapsTest.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'ConvertM1M2TestCase.php';
+
+class AllCaps extends ConvertM1M2TestCase
+{
+    public function testAllcaps()
+    {
+        $object = new TestableConvertM1M2();
+        $contents = $object->convertCodeContents('<' . '?' . 'php' . "\n" . 
+            'class FOO_Module_TestController{}');
+     
+        $this->assertContains('Module\\', $contents);   
+        $this->assertNotContains('FOO_\\', $contents);   
+    }
+    
+    public function testMethodParsingNoCaps()
+    {
+        $object = new TestableConvertM1M2();
+        $contents = $object->convertCodeContents('<' . '?' . 'php' . "\n" . 
+            'class Foo_Module_TestController{ public function indexAction(){}}');        
+        $contents = $object->convertCodeParseMethods($contents, 'php');
+        $currentFile = $object->getCurrentFile();     
+        $this->assertTrue(count($currentFile['methods']));
+    }
+
+    public function testMethodParsingAllCaps()
+    {
+        $object = new TestableConvertM1M2();
+        $contents = $object->convertCodeContents('<' . '?' . 'php' . "\n" . 
+            'class FOO_Module_TestController{ public function indexAction(){}}');        
+        $contents = $object->convertCodeParseMethods($contents, 'php');
+        $currentFile = $object->getCurrentFile();     
+        $this->assertTrue(count($currentFile['methods']));
+    }    
+}

--- a/tests/ConvertM1M2TestCase.php
+++ b/tests/ConvertM1M2TestCase.php
@@ -5,6 +5,12 @@ class ConvertM1M2TestCase extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         require_once __DIR__ . '/../ConvertM1M2.php';
+        require_once __DIR__ . '/TestableConvertM1M2.php';
+    }
+    
+    public function testAvoidNoTestsFound()
+    {
+        $this->assertTrue(true);
     }
 }
 

--- a/tests/TestableConvertM1M2.php
+++ b/tests/TestableConvertM1M2.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Overrides constructor to avoid needing directory
+ * May not handle all cases -- i.e. things that require
+ * some sort of state enabled by the constructor, or by 
+ * previous methods being called.  
+ */
+class TestableConvertM1M2 extends ConvertM1M2
+{
+    public function __construct()
+    {
+        $this->_replace = $this->getReplaceMaps();
+    }
+    
+    public function getCurrentFile()
+    {
+        return $this->_currentFile;
+    }
+}


### PR DESCRIPTION
This pull request 

1. Adds a `test` script to the composer.json file, so we can run tests easily
2. Adds test cases for the issue described in https://github.com/unirgy/convertm1m2/issues/40
3. Adds a testable version of the `ConvertM1M2` class that doesn't rely on files being there

You can run tests by installing the composer dependencies 

    $ composer install

and then running

    $ composer test
    $ composer.phar test
    > vendor/bin/phpunit tests
    PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

    .FFF...

    Time: 60 ms, Memory: 6.00Mb

    There were 3 failures:

    1) AllCaps::testAllcaps
    Failed asserting that '<?php
    class FOO_\Module\Controller\Test\AbstractTest{}' does not contain "FOO_\".

    /Users/alanstorm/Documents/github/astorm/convertm1m2/tests/AllcapsTest.php:13

    2) AllCaps::testMethodParsingNoCaps
    Failed asserting that 0 is true.

    /Users/alanstorm/Documents/github/astorm/convertm1m2/tests/AllcapsTest.php:23

    3) AllCaps::testMethodParsingAllCaps
    Failed asserting that 0 is true.

    /Users/alanstorm/Documents/github/astorm/convertm1m2/tests/AllcapsTest.php:33

    FAILURES!
    Tests: 7, Assertions: 8, Failures: 3.
    Script vendor/bin/phpunit tests handling the test event returned with error code 1

There are currently failures because the new tests provide coverage that demonstrates the problems in https://github.com/unirgy/convertm1m2/issues/40.  

   